### PR TITLE
8-5　ブログ投稿の編集

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -28,6 +28,18 @@ class PostController extends Controller
         $post->fill($input)->save();
         return redirect('/posts/' . $post->id);
     }
+    
+    public function edit(Post $post)
+    {
+        return view('posts/edit')->with(['post' => $post]);
+    }
+    
+    public function update(PostRequest $request, Post $post)
+    {
+        $input = $request['post'];
+        $post->fill($input)->save();
+        return redirect('/posts/' . $post->id);
+    }
 }
 ?>
 

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <title>Blog</title>
+    </head>
+    <body>
+        <h1>Blog Name</h1>
+        <form action="/posts/{{ $post->id}}" method="POST">
+            @csrf
+            @method('PUT')
+            <div class="title">
+                <h2>Title</h2>
+                <input type="text" name="post[title]" placeholder="タイトル" value="{{ $post->title }}"/>
+            </div>
+            <div class="body">
+                <h2>Body</h2>
+                <textarea name="post[body]" placeholder="今日も1日お疲れさまでした。">{{ $post->body }}</textarea>
+            </div> 
+            <input type="submit" value="update"/>
+        </form>
+        <div class="back">[<a href="/posts/{{ $post->id}}">back</a>]</div>
+    </body>
+</html>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -11,6 +11,7 @@
     </head>
     <body>
        <h1>Blog Name</h1>
+       <p class="edit">[<a href="/posts/{{ $post->id }}/edit">edit</a>]</p>
         <div class = 'post'>
             <h2 class = 'title'>
                 <a href = "/posts/{{$post->id}}">{{ $post -> title }}</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@
 
 Route::get('/', 'PostController@index');
 Route::get('/posts/create','PostController@create');
+Route::get('/posts/{post}/edit','PostController@edit');
+Route::put('/posts/{post}','PostController@update');
 Route::get('/posts/{post}', 'PostController@show');
 
 Route::post('/posts','PostController@store');


### PR DESCRIPTION
ブランチの内容が消えるバグの対策を発見
ブランチ変更の際に毎回消えてしまうが、変更せずにそのままのブランチで実行すれば一人で作成する分には問題ない